### PR TITLE
Update PubListener.swift

### DIFF
--- a/Millicast SDK Sample App in Swift/PubListener.swift
+++ b/Millicast SDK Sample App in Swift/PubListener.swift
@@ -24,6 +24,8 @@ class PubListener : MCPublisherListener {
         print("[PubLtn] Publishing to Millicast.")
     }
     
+    func onPublishingError(_ error: String!) { }
+    
     func onConnected() {
         mcMan.setPubState(to: .connected)
         print("[PubLtn] Connected to Millicast.")


### PR DESCRIPTION
Also missing onPublishingError(_ error: String!) protocol method from MCPublisherListener
Note: likely additional protocol methods seen here might be obsolete.   Discovered via Xcode errors on missing methods.