### PR TITLE
DIOS-2542 Add recording controls to test apps

### DIFF
--- a/Millicast SDK Sample App in Swift/MCStates.swift
+++ b/Millicast SDK Sample App in Swift/MCStates.swift
@@ -37,3 +37,8 @@ enum SubscriberState {
     case connected
     case subscribing
 }
+
+enum RecordingState {
+    case recording
+    case notRecording
+}

--- a/Millicast SDK Sample App in Swift/PublishView.swift
+++ b/Millicast SDK Sample App in Swift/PublishView.swift
@@ -25,6 +25,8 @@ struct PublishView: View {
     static let labelVideoNo = "No Video"
     static let labelVideoMute = "Mute Video"
     static let labelVideoUnmute = "Unmute Video"
+    static let labelRecordingOn = "Recording"
+    static let labelRecordingOff = "Not Recording "
     
     var mcSA: MillicastSA = .getInstance()
     
@@ -82,6 +84,12 @@ struct PublishView: View {
                     mcSA.toggleMedia(forPublisher: true, forAudio: false)
                 }.padding().disabled(!getEnableVideo())
                 
+                Button(getLabelRecording()){
+                    print("[PubView] Toggled Recording.")
+                    mcMan.toggleRecording()
+                    
+                }
+                
                 Button(getLabelPublish()) {
                     print("[PubView] Publish.")
                     getActionPublish()()
@@ -110,7 +118,8 @@ struct PublishView: View {
                          actionPublish: () -> (),
                          enablePublish: Bool,
                          enableAudio: Bool,
-                         enableVideo: Bool)
+                         enableVideo: Bool,
+                         labelRecording: String)
     {
         var labelCapture = ""
         var actionCapture: (() -> ()) = {}
@@ -120,6 +129,7 @@ struct PublishView: View {
         var labelPublish = ""
         var actionPublish: (() -> ()) = {}
         var enablePublish = false
+        var labelRecording = ""
         // Whether to enable buttons for Audio/Video on the UI.
         var enableAudio = false
         var enableVideo = false
@@ -161,10 +171,17 @@ struct PublishView: View {
             enableVideo = false
         }
         
+        switch mcMan.recState {
+        case .recording:
+            labelRecording = PublishView.labelRecordingOn
+        case .notRecording:
+            labelRecording = PublishView.labelRecordingOff
+        }
+        
         if !readyToPublish {
             if mcMan.pubState == .disconnected {
                 labelPublish = PublishView.labelPublishNot
-                return (labelCapture, actionCapture, enableCapture, enableSwitchCam, enableSwitchAudioOnly, labelPublish, actionPublish, enablePublish, enableAudio, enableVideo)
+                return (labelCapture, actionCapture, enableCapture, enableSwitchCam, enableSwitchAudioOnly, labelPublish, actionPublish, enablePublish, enableAudio, enableVideo,labelRecording)
             }
         }
         
@@ -189,7 +206,7 @@ struct PublishView: View {
             enableVideo = false
         }
         
-        return (labelCapture, actionCapture, enableCapture, enableSwitchCam, enableSwitchAudioOnly, labelPublish, actionPublish, enablePublish, enableAudio, enableVideo)
+        return (labelCapture, actionCapture, enableCapture, enableSwitchCam, enableSwitchAudioOnly, labelPublish, actionPublish, enablePublish, enableAudio, enableVideo,labelRecording)
     }
     
     /**
@@ -216,6 +233,10 @@ struct PublishView: View {
     
     func getLabelCapture() -> String {
         return getStates().labelCapture
+    }
+    
+    func getLabelRecording() -> String{
+        return getStates().labelRecording
     }
     
     func getActionCapture() -> (() -> ()) {

--- a/Millicast SDK Sample App in Swift/RecListener.swift
+++ b/Millicast SDK Sample App in Swift/RecListener.swift
@@ -1,0 +1,42 @@
+//
+//  RecListener.swift
+//  Millicast SDK Sample App in Swift
+//
+
+import Foundation
+import MillicastSDK
+
+/**
+ * Implementation of Publisher's Recording Listener.
+ * This handles events sent to the Publisher regarding recording events.
+ */
+class RecListener: MCRecordingListener {
+    
+    
+    private var mcMan: MillicastManager
+    private let tag = "[Pub][RecLtn]"
+    
+    init() {
+        let logTag = "\(tag) "
+        mcMan = MillicastManager.getInstance()
+        print(logTag + "RecListener created.")
+    }
+    
+    func ownRecordingStarted() {
+        print(tag + "Started recording the active stream")
+        mcMan.setRecordingEnabled(enabled: true)
+    }
+    
+    func ownRecordingStopped() {
+        print(tag + "Stopped recording the active stream")
+        mcMan.setRecordingEnabled(enabled: false)
+    }
+    
+    func failedToStartRecording() {
+        print(tag + "Failed to start recording the active stream")
+    }
+    
+    func failedToStopRecording() {
+        print(tag + "Failed to stop recording the active stream")
+    }
+}


### PR DESCRIPTION
- Added a button to toggle recording the stream
- If not publishing, set a flag in publisher options, otherwise call `record()`/`unrecord()` to toggle recording the active stream