### PR TITLE
[ENH] DIOS-2412 Add MediaSettingsView

### DIFF
--- a/Millicast SDK Sample App in Swift/ContentView.swift
+++ b/Millicast SDK Sample App in Swift/ContentView.swift
@@ -29,6 +29,10 @@ struct ContentView: View {
                     Text("Settings")
                 }
                 Spacer()
+                NavigationLink(destination: mcSA.getMediaSettingsView){
+                    Text("Media Settings")
+                }
+                Spacer()
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())

--- a/Millicast SDK Sample App in Swift/MCTypes.swift
+++ b/Millicast SDK Sample App in Swift/MCTypes.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-
+import MillicastSDK
 /**
  * Enums for types used in the Sample App.
  */
@@ -25,4 +25,32 @@ enum Bitrate {
      * maxBitrateKbps
      */
     case MAX
+}
+
+
+
+
+struct VideoSourceWrapper : Identifiable{
+    let source: MCVideoSource
+    let id :Int
+}
+
+struct AudioSourceWrapper: Identifiable{
+    let source: MCAudioSource
+    let id: Int
+}
+
+struct CapabilityWrapper: Identifiable{
+    let capability: MCVideoCapabilities
+    let id : Int
+}
+
+struct CodecWrapper:Identifiable{
+    let codec:String
+    let id: Int
+}
+
+struct AudioPlaybackWrapper: Identifiable{
+    let audioPlayback: MCAudioPlayback
+    let id: Int
 }

--- a/Millicast SDK Sample App in Swift/MediaSettingsView.swift
+++ b/Millicast SDK Sample App in Swift/MediaSettingsView.swift
@@ -1,0 +1,114 @@
+//
+//  SettingsMediaView.swift
+//  SwiftSa iOS
+//
+//  Created by Szymczak, Marcin on 28/12/2023.
+//
+
+import Foundation
+
+
+import AVFoundation
+import SwiftUI
+import MillicastSDK
+
+/**
+ * UI for Millicast platform settings.
+ */
+struct MediaSettingsView: View {
+    
+    @ObservedObject var mcMan: MillicastManager
+    
+    init(manager mcMan: MillicastManager) {
+        self.mcMan = mcMan
+    }
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 0.0) {
+            VStack(){
+                HStack {
+                    Text("Media Capture Settings")
+                        .font(.title3)
+                    .fontWeight(.bold)
+                }.frame(
+                    minWidth: 0,
+                    maxWidth: .infinity,
+                    alignment: .center
+                  )
+                List {
+                    Picker("Video Source", selection: $mcMan.videoSourceIndex) {
+                        ForEach(mcMan.getWrappedVideoSourceList()){src in
+                            Text("\(src.source.getName()) [\(src.id)]").tag(src.id)
+                        }
+                    }
+                    .onChange(of: mcMan.videoSourceIndex){tag in mcMan.setVideoSourceIndex(tag, setCapIndex: true)}
+                    .disabled(mcMan.capState == .isCaptured)
+                    
+                    Picker("Video Capability", selection: $mcMan.capabilityIndex) {
+                        ForEach(mcMan.getWrappedCapabilityList()){cap in
+                            Text("\(cap.capability.width)x\(cap.capability.height)x\(cap.capability.fps) [\(cap.id)]").tag(cap.id)
+                        }
+                    }
+                    .onChange(of: mcMan.capabilityIndex){tag in mcMan.setCapabilityIndex(tag)}
+                    
+                    
+                    Picker("Audio Source", selection: $mcMan.audioSourceIndex) {
+                        ForEach(mcMan.getWrappedAudioSourceList()){src in
+                            Text(src.source.getName()).tag(src.id)
+                        }
+                    }
+                    .onChange(of: mcMan.audioSourceIndex){tag in mcMan.setAudioSourceIndex(tag)}
+                    
+                    
+                    Toggle(isOn: $mcMan.audioOnly, label: {
+                        Text("Audio only")
+                    })
+                    
+                }.listStyle(PlainListStyle())
+            }
+            
+            Spacer()
+            VStack(){
+                    Text("Publish Settings")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                    List {
+                        Picker("Audio Codecs", selection: $mcMan.audioCodecIndex) {
+                            ForEach(mcMan.getWrappedCodecList(forAudio: true)){wrapped in
+                                Text(wrapped.codec).tag(wrapped.id)
+                            }
+                        }
+                        .onChange(of: mcMan.audioCodecIndex){tag in mcMan.setCodecIndex(newValue: tag, forAudio: true)}
+                        
+                        Picker("Video Codecs", selection: $mcMan.videoCodecIndex) {
+                            ForEach(mcMan.getWrappedCodecList(forAudio: false)){wrapped in
+                                Text(wrapped.codec).tag(wrapped.id)
+                            }
+                        }
+                        .onChange(of: mcMan.videoCodecIndex){tag in mcMan.setCodecIndex(newValue: tag, forAudio: false)}
+                    }.listStyle(PlainListStyle())
+            }
+            Spacer()
+            VStack(){
+                Text("Subscribe Settings")
+                    .font(.title3)
+                    .fontWeight(.bold)
+                List {
+                    Picker("Audio Playback Device", selection: $mcMan.audioPlaybackIndex) {
+                        ForEach(mcMan.getWrappedAudioPlaybackList()){wrapped in
+                            Text(wrapped.audioPlayback.getName()).tag(wrapped.id)
+                        }
+                    }
+                    .onChange(of: mcMan.audioPlaybackIndex){tag in mcMan.setAudioPlaybackIndex(newValue: tag)}
+                }.listStyle(PlainListStyle())
+                Spacer()
+            }
+        }
+    }
+}
+
+struct MediaSettingsView_Previev: PreviewProvider {
+    static var previews: some View {
+        MediaSettingsView(manager: MillicastManager.getInstance())
+    }
+}

--- a/Millicast SDK Sample App in Swift/MillicastSA.swift
+++ b/Millicast SDK Sample App in Swift/MillicastSA.swift
@@ -179,6 +179,11 @@ class MillicastSA: ObservableObject {
         return SettingsMcView(manager: mcMan)
     }
     
+    func getMediaSettingsView() -> MediaSettingsView {
+        print("[McSA][getMediaSettingsView]")
+        return MediaSettingsView(manager: mcMan)
+    }
+    
     /*
      Utils
      */

--- a/SwiftSa.xcodeproj/project.pbxproj
+++ b/SwiftSa.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		8695907B28911F6B003CE073 /* UiCreds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8695907528911F6B003CE073 /* UiCreds.swift */; };
 		8697685D29431BAF00055C0D /* MCTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697685C29431BAF00055C0D /* MCTypes.swift */; };
 		8697685E29431BAF00055C0D /* MCTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697685C29431BAF00055C0D /* MCTypes.swift */; };
+		B3DDE5822B4C265B002C102B /* MediaSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDE5812B4C265B002C102B /* MediaSettingsView.swift */; };
+		B3DDE5842B4C26C8002C102B /* RecListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDE5832B4C26C8002C102B /* RecListener.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +113,8 @@
 		8695907428911F6B003CE073 /* FileCreds.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileCreds.swift; sourceTree = "<group>"; };
 		8695907528911F6B003CE073 /* UiCreds.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UiCreds.swift; sourceTree = "<group>"; };
 		8697685C29431BAF00055C0D /* MCTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCTypes.swift; sourceTree = "<group>"; };
+		B3DDE5812B4C265B002C102B /* MediaSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSettingsView.swift; sourceTree = "<group>"; };
+		B3DDE5832B4C26C8002C102B /* RecListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecListener.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +181,8 @@
 		3FE90C1A26B2AF4200B206A3 /* Millicast SDK Sample App in Swift */ = {
 			isa = PBXGroup;
 			children = (
+				B3DDE5812B4C265B002C102B /* MediaSettingsView.swift */,
+				B3DDE5832B4C26C8002C102B /* RecListener.swift */,
 				3FA8DBA82704AECD009713E8 /* README.md */,
 				3FE90C1B26B2AF4200B206A3 /* Millicast_SDK_Sample_App_in_SwiftApp.swift */,
 				3FE90C1D26B2AF4200B206A3 /* ContentView.swift */,
@@ -400,6 +406,7 @@
 				86625CF92913B03600305683 /* MCSwiftVideoRenderer.swift in Sources */,
 				8695907628911F6B003CE073 /* CurrentCreds.swift in Sources */,
 				3FAC2F9926B93635007588CA /* MillicastSA.swift in Sources */,
+				B3DDE5842B4C26C8002C102B /* RecListener.swift in Sources */,
 				3FB2293126C3DE9000982391 /* Constants.swift in Sources */,
 				3F8DC0A226BA98E7009D51B1 /* PubListener.swift in Sources */,
 				3FB131C626B3EB2E00800DC5 /* SettingsMcView.swift in Sources */,
@@ -414,6 +421,7 @@
 				3FB31BFD26CB9ADC00A0A056 /* CredentialSource.swift in Sources */,
 				3FB131C526B3EB2E00800DC5 /* SubscribeView.swift in Sources */,
 				8697685D29431BAF00055C0D /* MCTypes.swift in Sources */,
+				B3DDE5822B4C265B002C102B /* MediaSettingsView.swift in Sources */,
 				3FB31BFF26CBA1D300A0A056 /* SavedCreds.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
**Summary**
Added a `MediaSettingsView` which lets the user set capture/publish/subscribe parameters

**Details**
Setting the video source/capability in the app is only possible in the `PublishView` by cycling through available options, which is tedious when there can be >20 capabilities to select from. Other than that, setting audio/video codecs was not possible at all.  
The new view allows the user to select from expandable  lists (Swift's `Picker` elements) the desired audio/video

- codecs,
- sources
- capabilities

Similarly to the Android app, the `Audio Only` switch is also present here. 

P.S. Sorry about the huge MillicastManager diff,  had the whitespace diff turned off...

![IMG_069BDCB1580F-1](https://github.com/millicast/Millicast-ObjC-SDK-iOS-Sample-App-in-Swift/assets/138568879/30070db0-a9e3-47a2-9664-0209da69ed8b)
